### PR TITLE
added /upload-resource endpoint to api

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -112,6 +112,34 @@ def uploadImage():
     return d['secure_url']
 
 
+@app.route("/upload-resource", methods=["POST"])
+def uploadResource():
+    """
+    Upload resource to Cloudinary
+    """
+
+    if ("image" in request.files):
+        resource = request.files["image"]
+        resource_type = "image"
+    elif ("video" in request.files):
+        resource = request.files["video"]
+        resource_type = "video"
+    elif ("raw" in request.files):
+        resource = request.files["raw"]
+        resource_type = "raw"
+    else:
+        print("error")
+        return "error"
+    
+    d = cloudinary.uploader.upload(resource, 
+        folder = "", 
+        public_id = resource.filename,
+        overwrite = True, 
+        resource_type = resource_type)
+
+    return d['secure_url']
+
+
 
 if __name__ == "__main__":
     app.run()


### PR DESCRIPTION
Addresses Issue #6 

Added to help address calpoly-csai/argo-editor-frontend#2

Adds a "/upload-resource" endpoint to the api. Preserves the /upload-image endpoint for now.

Note: Cases where multiple kinds of files are included in a request aren't explicitly handled. For example, sending a request with both a video and an image file will only handle/store the image file.